### PR TITLE
PIA-620: Update iOS `KeychainSettings` constructor to pass the `kSecAttrAccessible` attribute

### DIFF
--- a/account/src/iosMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
+++ b/account/src/iosMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
@@ -1,12 +1,22 @@
 package com.privateinternetaccess.account.internals.persistency.secureSettings
 
+import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.CFBridgingRetain
+import platform.Security.kSecAttrAccessible
+import platform.Security.kSecAttrAccessibleAlways
+import platform.Security.kSecAttrService
 
 internal actual object SecureSettingsProvider {
 
     private const val KEYCHAIN_NAME = "account_keychain"
 
+    @OptIn(ExperimentalSettingsImplementation::class, ExperimentalForeignApi::class)
     actual val settings: Settings?
-        get() = KeychainSettings(KEYCHAIN_NAME)
+        get() = KeychainSettings(
+            kSecAttrService to CFBridgingRetain(KEYCHAIN_NAME),
+            kSecAttrAccessible to kSecAttrAccessibleAlways
+        )
 }


### PR DESCRIPTION
## Summary

As per title. It updates the constructor to pass the `kSecAttrAccessible` property with its `kSecAttrAccessibleAlways` value, as its default value seems to be `kSecAttrAccessibleWhenUnlocked` which is throwing some exceptions when trying to access data on the locked state.

## Sanity Tests

TBD