### PR TITLE
PIA-684: Introduce keychain migration logic

### DIFF
--- a/account/src/androidMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
+++ b/account/src/androidMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
@@ -16,7 +16,5 @@ internal actual object SecureSettingsProvider {
     // No change. The deprecated settings is for iOS only due to
     // its constructor kSecAttrAccessible change.
     actual val deprecatedSettings: Settings?
-        get() = AccountContextProvider.applicationContext?.let { context ->
-            EncryptedSettingsFactory(context).create(SHARED_PREFS_NAME)
-        }
+        get() = settings
 }

--- a/account/src/androidMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
+++ b/account/src/androidMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
@@ -12,4 +12,11 @@ internal actual object SecureSettingsProvider {
         get() = AccountContextProvider.applicationContext?.let { context ->
             EncryptedSettingsFactory(context).create(SHARED_PREFS_NAME)
         }
+
+    // No change. The deprecated settings is for iOS only due to
+    // its constructor kSecAttrAccessible change.
+    actual val deprecatedSettings: Settings?
+        get() = AccountContextProvider.applicationContext?.let { context ->
+            EncryptedSettingsFactory(context).create(SHARED_PREFS_NAME)
+        }
 }

--- a/account/src/commonMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
+++ b/account/src/commonMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
@@ -3,5 +3,6 @@ package com.privateinternetaccess.account.internals.persistency.secureSettings
 import com.russhwolf.settings.Settings
 
 internal expect object SecureSettingsProvider {
+    val deprecatedSettings: Settings?
     val settings: Settings?
 }

--- a/account/src/iosMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
+++ b/account/src/iosMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
@@ -19,4 +19,10 @@ internal actual object SecureSettingsProvider {
             kSecAttrService to CFBridgingRetain(KEYCHAIN_NAME),
             kSecAttrAccessible to kSecAttrAccessibleAlways
         )
+
+    @OptIn(ExperimentalSettingsImplementation::class, ExperimentalForeignApi::class)
+    actual val deprecatedSettings: Settings?
+        get() = KeychainSettings(
+            kSecAttrService to CFBridgingRetain(KEYCHAIN_NAME)
+        )
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library").version("7.3.1").apply(false)
-    kotlin("multiplatform").version("1.9.0").apply(false)
-    kotlin("plugin.serialization").version("1.9.0").apply(false)
+    kotlin("multiplatform").version("1.9.10").apply(false)
+    kotlin("plugin.serialization").version("1.9.10").apply(false)
 }
 
 tasks.register("clean", Delete::class) {


### PR DESCRIPTION
## Summary

- It introduces the migration logic for iOS to move the keys to the `kSecAttrAccessibleAlways` new Keychain scope.
- It bumps Kotlin to 1.9.10 to address some incompatibility issues when compiling with Xcode 15.

## Sanity Tests

- [x] Clean installation. Login. Confirm we can login successfully.
- [x] After the above. Go to the dashboard. Tap on 3x regions. Confirm we can connect successfully.