### PR TITLE
PIA-832: Add compatibility with iOS 12

### DIFF
--- a/account/build.gradle.kts
+++ b/account/build.gradle.kts
@@ -65,6 +65,11 @@ kotlin {
         tvosSimulatorArm64(),
         tvosArm64()
     ).forEach {
+        val main by it.compilations.getting {
+            val fixUndefinedSymbols by cinterops.creating {
+                defFile(project.file("src/iosMain/cinterop/fix_undefined_symbols.def"))
+            }
+        }
         it.binaries.framework {
             xcf.add(this)
         }

--- a/account/src/iosMain/cinterop/fix_undefined_symbols.def
+++ b/account/src/iosMain/cinterop/fix_undefined_symbols.def
@@ -1,0 +1,3 @@
+package = fix_undefined_symbols
+---
+void * OBJC_CLASS_$_NSURLSessionWebSocketMessage = 0;

--- a/account/src/iosMain/kotlin/com/privateinternetaccess/account/internals/AccountHttpClient.kt
+++ b/account/src/iosMain/kotlin/com/privateinternetaccess/account/internals/AccountHttpClient.kt
@@ -35,7 +35,7 @@ internal actual object AccountHttpClient {
         certificate: String?,
         pinnedEndpoint: Pair<String, String>?
     ): Pair<HttpClient?, Exception?> {
-        return Pair(HttpClient(Ios) {
+        return Pair(HttpClient(Darwin) {
             expectSuccess = false
             install(HttpTimeout) {
                 requestTimeoutMillis = Account.REQUEST_TIMEOUT_MS


### PR DESCRIPTION
- Fixes a crash upon launch due to an undefined symbol on iOS 12
- NSURLSessionWebSocketMessage is only available on iOS 13+