### PR TITLE
PIA-978: Return null on Android for the iOS specific deprecated settings change

### DIFF
--- a/account/src/androidMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
+++ b/account/src/androidMain/kotlin/com/privateinternetaccess/account/internals/persistency/secureSettings/SecureSettingsProvider.kt
@@ -16,5 +16,5 @@ internal actual object SecureSettingsProvider {
     // No change. The deprecated settings is for iOS only due to
     // its constructor kSecAttrAccessible change.
     actual val deprecatedSettings: Settings?
-        get() = settings
+        get() = null
 }


### PR DESCRIPTION
## Summary

Given the introduction of the deprecated settings for the migration of iOS to a new `kSecAttrAccessible` property, we've decided to return the same settings object for Android. For most cases this is fine, but on old devices reading/writing all values seems to be triggering a deadlock within the Keystore. Let's return `null` which would prevent us from the unnecessary logic of migrating to the same settings object.

This is a speculative fix for the issue where the application is freezing on the 1st gen Firestick when launching the application.

## Sanity Tests

- [x] Introduce RC to the application. Confirm via logging we are operating on one instance of the settings to begin with.